### PR TITLE
Rebrand CleanWork to Mutuus with new login logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/webp" href="https://app.mutuus-app.de/assets/mutuuslogo9.webp" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Job Dashboard with Animated Navigation</title>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -255,9 +255,9 @@ function App() {
       }
       
       // Check if profile needs updates (missing name or default values)
-      const needsUpdate = !profile?.full_name || 
-                         profile.full_name === 'CleanWork' || 
-                         profile.full_name === 'CleanWork User' ||
+      const needsUpdate = !profile?.full_name ||
+                         profile.full_name === 'Mutuus' ||
+                         profile.full_name === 'Mutuus User' ||
                          profile.full_name.trim() === '';
       
       setProfileNeedsUpdate(needsUpdate);
@@ -420,7 +420,7 @@ function App() {
           .insert({
             id: userId,
             email: user?.email || '',
-            full_name: user?.user_metadata?.full_name || 'CleanWork User',
+            full_name: user?.user_metadata?.full_name || 'Mutuus User',
             karma: 0,
             level: 1,
             premium: false,
@@ -862,7 +862,7 @@ function App() {
             </button>
             <div>
               <h1 className={`font-bold text-lg ${isDark ? 'text-white' : 'text-gray-900'} transition-colors duration-500`}>
-                {userProfile?.full_name || 'CleanWork'}
+                {userProfile?.full_name || 'Mutuus'}
               </h1>
               <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'} transition-colors duration-500`}>
                 Karma: {karmaPoints} Punkte {todayKarmaEarned > 0 ? `(+${todayKarmaEarned} heute!)` : ''}

--- a/src/components/AuthPage.tsx
+++ b/src/components/AuthPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { supabase } from '../lib/supabase';
-import { Eye, EyeOff, Mail, Lock, User, X, Zap } from 'lucide-react';
+import { Eye, EyeOff, Mail, Lock, User, X } from 'lucide-react';
 
 interface AuthPageProps {
   onAuthSuccess: () => void;
@@ -198,9 +198,13 @@ const AuthPage: React.FC<AuthPageProps> = ({ onAuthSuccess }) => {
         {/* Logo */}
         <div className="text-center mb-8">
           <div className="w-20 h-20 bg-gradient-to-br from-blue-500 to-purple-600 rounded-2xl flex items-center justify-center mx-auto mb-4 shadow-lg shadow-blue-500/30">
-            <Zap className="w-10 h-10 text-white" />
+            <img
+              src="https://app.mutuus-app.de/assets/mutuuslogo9.webp"
+              alt="Mutuus Logo"
+              className="w-16 h-16 object-contain"
+            />
           </div>
-          <h1 className="text-3xl font-bold text-white mb-2">CleanWork</h1>
+          <h1 className="text-3xl font-bold text-white mb-2">Mutuus Karma Exchange</h1>
           
           {/* Beta Offer */}
           <div className="bg-gradient-to-r from-green-500/20 to-emerald-500/20 border border-green-500/30 rounded-2xl p-4 mb-6">

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -685,7 +685,7 @@ const MoreMenu: React.FC<MoreMenuProps> = ({ isDark, onToggleTheme }) => {
             </div>
             <div className="flex-1">
               <h3 className={`font-bold text-lg ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                {userProfile?.full_name || 'CleanWork User'}
+                {userProfile?.full_name || 'Mutuus User'}
               </h3>
               <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                 {userProfile?.email || user?.email}

--- a/supabase/migrations/20250822160000_update_mutuus_user.sql
+++ b/supabase/migrations/20250822160000_update_mutuus_user.sql
@@ -1,0 +1,40 @@
+/*
+  Update default profile name to 'Mutuus User'
+*/
+
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS trigger
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  INSERT INTO public.profiles (
+    id,
+    email,
+    full_name,
+    karma,
+    level,
+    premium,
+    login_streak,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', 'Mutuus User'),
+    0,
+    1,
+    false,
+    0,
+    NOW(),
+    NOW()
+  );
+  RETURN NEW;
+EXCEPTION
+  WHEN others THEN
+    RAISE LOG 'Error creating profile for user %: %', NEW.id, SQLERRM;
+    RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary
- show Mutuus logo and title on login screen
- rename CleanWork references to Mutuus across UI and defaults
- update Supabase profile trigger to default to "Mutuus User"

## Testing
- `npm run lint` *(fails: 61 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68abaf003648832ea0dec9ffed0f577e