### PR TITLE
refactor: centralize notification handling

### DIFF
--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,30 +1,34 @@
 import React, { useEffect, useState } from 'react';
 import { Bell } from 'lucide-react';
+import { useNotifications } from './NotificationProvider';
 
 interface NotificationBellProps {
-  unread: number;
   onClick?: () => void;
 }
 
-const NotificationBell: React.FC<NotificationBellProps> = ({ unread, onClick }) => {
+const NotificationBell: React.FC<NotificationBellProps> = ({ onClick }) => {
+  const { unreadCount } = useNotifications();
   const [glow, setGlow] = useState(false);
 
   useEffect(() => {
-    if (unread > 0) {
+    if (unreadCount > 0) {
       setGlow(true);
       const t = setTimeout(() => setGlow(false), 2000);
       return () => clearTimeout(t);
     }
-  }, [unread]);
+  }, [unreadCount]);
 
   return (
-    <button onClick={onClick} className="relative text-gray-700 dark:text-gray-200">
+    <button
+      onClick={onClick}
+      className="relative p-2 rounded-full hover:bg-slate-700/50 text-gray-700 dark:text-gray-200 transition-colors"
+    >
       <Bell className={`w-6 h-6 ${glow ? 'pulse-glow' : ''}`} />
-      {unread > 0 && (
+      {unreadCount > 0 && (
         <>
           <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-orange-500 rounded-full pulse-glow" />
           <span className="absolute -top-1 -right-2 px-1 bg-red-600 text-white text-xs rounded-full">
-            {unread}
+            {unreadCount}
           </span>
         </>
       )}

--- a/src/components/NotificationProvider.tsx
+++ b/src/components/NotificationProvider.tsx
@@ -1,0 +1,135 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { supabase, Notification } from '../lib/supabase';
+
+interface NotificationFlags {
+  newJobs: boolean;
+  newApplications: boolean;
+  karmaEarned: boolean;
+  profileIncomplete: boolean;
+  friendInvites: boolean;
+  achievements: boolean;
+  campusUpdates: boolean;
+}
+
+interface NotificationContextType {
+  notifications: Notification[];
+  unreadCount: number;
+  notificationStates: NotificationFlags;
+  setNotificationStates: React.Dispatch<React.SetStateAction<NotificationFlags>>;
+  refresh: () => Promise<void>;
+  markAsRead: (id: string) => Promise<void>;
+}
+
+const defaultFlags: NotificationFlags = {
+  newJobs: false,
+  newApplications: false,
+  karmaEarned: false,
+  profileIncomplete: false,
+  friendInvites: false,
+  achievements: false,
+  campusUpdates: false
+};
+
+const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
+
+export const NotificationProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [notificationStates, setNotificationStates] = useState<NotificationFlags>(defaultFlags);
+
+  const refresh = async () => {
+    if (!userId) return;
+    const { data, error } = await supabase
+      .from('notifications')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+    if (error) {
+      console.error('Error loading notifications:', error);
+      return;
+    }
+    setNotifications(data || []);
+    const flags = { ...defaultFlags };
+    data?.forEach(n => {
+      switch (n.type) {
+        case 'new_job':
+          flags.newJobs = true;
+          break;
+        case 'new_application':
+          flags.newApplications = true;
+          break;
+        case 'karma_earned':
+          flags.karmaEarned = true;
+          break;
+        case 'profile_incomplete':
+          flags.profileIncomplete = true;
+          break;
+        case 'friend_invite':
+          flags.friendInvites = true;
+          break;
+        case 'achievement':
+          flags.achievements = true;
+          break;
+        case 'campus_update':
+          flags.campusUpdates = true;
+          break;
+      }
+    });
+    setNotificationStates(flags);
+  };
+
+  const markAsRead = async (id: string) => {
+    const { error } = await supabase
+      .from('notifications')
+      .update({ read: true })
+      .eq('id', id);
+    if (error) {
+      console.error('Error marking notification as read:', error);
+      return;
+    }
+    setNotifications(prev => prev.map(n => n.id === id ? { ...n, read: true } : n));
+  };
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      setUserId(data.user?.id ?? null);
+    };
+    fetchUser();
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUserId(session?.user?.id ?? null);
+    });
+    return () => {
+      data.subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    if (!userId) return;
+    const channel = supabase
+      .channel('public:notifications')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${userId}` }, payload => {
+        setNotifications(prev => [payload.new as Notification, ...prev]);
+      })
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [userId]);
+
+  const unreadCount = notifications.filter(n => !n.read).length;
+
+  return (
+    <NotificationContext.Provider value={{ notifications, unreadCount, notificationStates, setNotificationStates, refresh, markAsRead }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotifications = () => {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) throw new Error('useNotifications must be used within NotificationProvider');
+  return ctx;
+};
+

--- a/src/components/NotificationsPage.tsx
+++ b/src/components/NotificationsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { useNotifications } from './NotificationProvider';
 import { 
   Bell, 
   Check, 
@@ -19,15 +20,6 @@ interface NotificationsPageProps {
   onBack: () => void;
 }
 
-interface Notification {
-  id: string;
-  type: string;
-  title: string;
-  message: string;
-  data: any;
-  read: boolean;
-  created_at: string;
-}
 
 interface Application {
   id: string;
@@ -44,7 +36,7 @@ interface Application {
 }
 
 const NotificationsPage: React.FC<NotificationsPageProps> = ({ isDark, onBack }) => {
-  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const { notifications, markAsRead } = useNotifications();
   const [applications, setApplications] = useState<Application[]>([]);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -52,24 +44,8 @@ const NotificationsPage: React.FC<NotificationsPageProps> = ({ isDark, onBack })
   const [readApplications, setReadApplications] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    loadNotifications();
     loadApplications();
   }, []);
-
-  const loadNotifications = async () => {
-    try {
-      const { data, error } = await supabase
-        .from('notifications')
-        .select('*')
-        .eq('user_id', 'temp-user-id') // TODO: Replace with actual user ID
-        .order('created_at', { ascending: false });
-
-      if (error) throw error;
-      setNotifications(data || []);
-    } catch (error) {
-      console.error('Error loading notifications:', error);
-    }
-  };
 
   const loadApplications = async () => {
     try {
@@ -104,28 +80,6 @@ const NotificationsPage: React.FC<NotificationsPageProps> = ({ isDark, onBack })
     return !readApplications.has(applicationId);
   };
 
-  const markAsRead = async (notificationId: string) => {
-    try {
-      const { error } = await supabase
-        .from('notifications')
-        .update({ read: true })
-        .eq('id', notificationId);
-
-      if (error) throw error;
-
-      setNotifications(prev => 
-        prev.map(n => n.id === notificationId ? { ...n, read: true } : n)
-      );
-      
-      // Trigger a refresh of notification states in parent component
-      const event = new CustomEvent('notificationRead', { 
-        detail: { notificationId } 
-      });
-      window.dispatchEvent(event);
-    } catch (error) {
-      console.error('Error marking notification as read:', error);
-    }
-  };
 
   const handleApplicationAction = async (applicationId: string, action: 'accepted' | 'rejected') => {
     setActionLoading(applicationId);

--- a/src/lib/notificationTemplates.ts
+++ b/src/lib/notificationTemplates.ts
@@ -1,0 +1,91 @@
+export type NotificationPriority = 'low' | 'medium' | 'high';
+
+export interface PushNotificationTemplate {
+  title: string;
+  message: string;
+  priority: NotificationPriority;
+}
+
+export const pushNotificationTemplates: Record<string, PushNotificationTemplate> = {
+  job_acceptance: {
+    title: "{{helper}} hat deinen Job '{{job}}' angenommen!",
+    message: 'Chat jetzt öffnen',
+    priority: 'high'
+  },
+  new_applicant: {
+    title: "{{count}} neue Bewerbungen für deinen Job '{{job}}'",
+    message: '',
+    priority: 'medium'
+  },
+  job_reminder: {
+    title: "Dein Job '{{job}}' startet in 1 Stunde",
+    message: '',
+    priority: 'high'
+  },
+  payment_released: {
+    title: "{{amount}}€ für '{{job}}' wurden freigegeben!",
+    message: 'Jetzt auszahlen',
+    priority: 'high'
+  },
+  karma_update: {
+    title: '+{{karma}} Karma! Du bist jetzt Level {{level}}',
+    message: '🏆',
+    priority: 'low'
+  },
+  new_job_nearby: {
+    title: "NEU: '{{job}}' ({{distance}}) - {{price}}€",
+    message: 'Jetzt ansehen',
+    priority: 'high'
+  },
+  leaderboard_update: {
+    title: 'Platz {{rank}} in {{region}}!',
+    message: 'Top {{percent}}% der Helfer 🔥',
+    priority: 'medium'
+  },
+  verification_success: {
+    title: 'ID-Verifikation abgeschlossen! Vollzugriff aktiv',
+    message: '',
+    priority: 'high'
+  }
+};
+
+export interface EmailTemplate {
+  subject: string;
+  intro: string;
+}
+
+export const emailTemplates: Record<string, EmailTemplate> = {
+  registration: {
+    subject: 'Willkommen bei Mutuus! Bestätige dein Konto',
+    intro: 'Verifizierungslink, App-Download-Links'
+  },
+  password_reset: {
+    subject: 'Passwort zurücksetzen für dein Mutuus-Konto',
+    intro: 'Reset-Link (24h gültig)'
+  },
+  job_confirmation: {
+    subject: "Job angenommen: {{job}}",
+    intro: 'Job-Details, Helfer-Profil, Chat-Link'
+  },
+  payment_confirmation: {
+    subject: 'Zahlung erhalten: {{amount}}€ für {{job}}',
+    intro: 'Transaktions-ID, Steuer-PDF'
+  },
+  weekly_digest: {
+    subject: 'Deine Woche bei Mutuus: {{amount}}€ + {{karma}} Karma',
+    intro: 'Statistiken, Top-Jobs der Woche'
+  },
+  karma_report: {
+    subject: 'Dein Karma-Report: {{karma}} gute Taten!',
+    intro: 'Abzeichen, Vergleich mit Vorher'
+  },
+  invitation_reminder: {
+    subject: '{{friend}}, dein Freund wartet auf dich!',
+    intro: 'Persönliche Nachricht, Nochmaliger Link'
+  },
+  mini_job_warning: {
+    subject: 'Achtung: Du näherst dich der 556€-Grenze',
+    intro: 'Aktueller Stand, Steuerhinweise'
+  }
+};
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { NotificationProvider } from './components/NotificationProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <NotificationProvider>
+      <App />
+    </NotificationProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add typed notification templates for push and email messages
- introduce NotificationProvider to manage unread state and realtime updates
- refactor bell and notifications page to consume centralized logic

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars', `no-explicit-any`)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abb02b5fb8832ea65c4b56d4114a5d