### PR TITLE
feat: allow avatar upload in profile

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { Image, Loader2 } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+
+interface AvatarUploadProps {
+  userId: string;
+  isDark: boolean;
+  avatarUrl: string;
+  onUpload: (url: string) => void;
+}
+
+const AvatarUpload: React.FC<AvatarUploadProps> = ({ userId, isDark, avatarUrl, onUpload }) => {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    setError('');
+
+    try {
+      const fileExt = file.name.split('.').pop();
+      const fileName = `${Date.now()}.${fileExt}`;
+      const filePath = `${userId}/${fileName}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from('avatars')
+        .upload(filePath, file, { upsert: true });
+      if (uploadError) throw uploadError;
+
+      const { data } = supabase.storage
+        .from('avatars')
+        .getPublicUrl(filePath);
+      if (data?.publicUrl) {
+        onUpload(data.publicUrl);
+      }
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div>
+      <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+        Profilbild
+      </label>
+      <div className="flex items-center space-x-4">
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt="Avatar"
+            className="w-16 h-16 rounded-full object-cover"
+          />
+        ) : (
+          <div
+            className={`w-16 h-16 rounded-full flex items-center justify-center border ${
+              isDark ? 'border-slate-600 bg-slate-700' : 'border-gray-200 bg-gray-50'
+            }`}
+          >
+            <Image className={`w-8 h-8 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+          </div>
+        )}
+        <div>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleFileChange}
+            disabled={uploading}
+            className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+          />
+          {uploading && <Loader2 className="w-4 h-4 animate-spin mt-2" />}
+          {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AvatarUpload;

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -266,6 +266,7 @@ const MoreMenu: React.FC<MoreMenuProps> = ({ isDark, onToggleTheme }) => {
             onSubmit={handleProfileUpdate}
             error={error}
             success={success}
+            userId={user?.id || ''}
           />
         </div>
       </div>

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -3,13 +3,13 @@ import {
   User,
   Mail,
   Link as LinkIcon,
-  Image,
   AtSign,
   FileText,
   Check,
   AlertCircle,
   Loader2
 } from 'lucide-react';
+import AvatarUpload from './AvatarUpload';
 
 export interface ProfileData {
   full_name: string;
@@ -29,6 +29,7 @@ interface ProfileFormProps {
   onSubmit: (e: React.FormEvent) => void;
   error: string;
   success: string;
+  userId: string;
 }
 
 const ProfileForm: React.FC<ProfileFormProps> = ({
@@ -38,7 +39,8 @@ const ProfileForm: React.FC<ProfileFormProps> = ({
   loading,
   onSubmit,
   error,
-  success
+  success,
+  userId
 }) => {
   return (
     <form onSubmit={onSubmit} className="space-y-6">
@@ -171,25 +173,12 @@ const ProfileForm: React.FC<ProfileFormProps> = ({
             </div>
           </div>
 
-          <div>
-            <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-              Profilbild URL
-            </label>
-            <div className="relative">
-              <Image className={`absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
-              <input
-                type="url"
-                value={profileData.avatar_url}
-                onChange={(e) => setProfileData(prev => ({ ...prev, avatar_url: e.target.value }))}
-                className={`w-full pl-12 pr-4 py-3 rounded-xl border transition-colors ${
-                  isDark
-                    ? 'bg-slate-700 border-slate-600 text-white placeholder-gray-400'
-                    : 'bg-gray-50 border-gray-200 text-gray-900 placeholder-gray-500'
-                } focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500`}
-                placeholder="https://example.com/bild.jpg"
-              />
-            </div>
-          </div>
+          <AvatarUpload
+            userId={userId}
+            isDark={isDark}
+            avatarUrl={profileData.avatar_url}
+            onUpload={(url) => setProfileData(prev => ({ ...prev, avatar_url: url }))}
+          />
         </div>
       </div>
 

--- a/supabase/migrations/20250827130000_create_avatars_bucket.sql
+++ b/supabase/migrations/20250827130000_create_avatars_bucket.sql
@@ -1,0 +1,16 @@
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+create policy "Avatar images are publicly accessible" on storage.objects
+  for select
+  using (bucket_id = 'avatars');
+
+create policy "Users can upload avatar images" on storage.objects
+  for insert
+  with check (bucket_id = 'avatars');
+
+create policy "Users can update avatar images" on storage.objects
+  for update
+  using (bucket_id = 'avatars')
+  with check (bucket_id = 'avatars');


### PR DESCRIPTION
## Summary
- support avatar image uploads with Supabase storage
- wire profile form to use new uploader and pass user id
- add database migration for public avatars bucket

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abc04f6780832eb2ae60b1d221d3fc