### PR TITLE
Publish lessons upon creation

### DIFF
--- a/src/components/CampusPage.tsx
+++ b/src/components/CampusPage.tsx
@@ -1284,7 +1284,8 @@ const user: User = {
                           content: lesson.description, // Using description as content for now
                           code_example: lesson.hasCode ? lesson.codeContent : null,
                           karma_reward: 25,
-                          order_index: i
+                          order_index: i,
+                          is_published: true
                         })
                         .select()
                         .single();

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -32,6 +32,9 @@ export interface Lesson {
   code_example: string | null;
   karma_reward: number;
   order_index: number;
+  is_published: boolean;
+  difficulty_level: 'beginner' | 'intermediate' | 'advanced';
+  estimated_duration: number | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- Ensure new lessons created via CampusPage are marked as published for public visibility
- Extend Supabase lesson typings with publication and difficulty metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 62 problems - unused vars and `any` types)*

------
https://chatgpt.com/codex/tasks/task_e_68abc078dd94832ea5167c975834b692