### PR TITLE
Implement support and legal pages

### DIFF
--- a/src/components/FAQPage.tsx
+++ b/src/components/FAQPage.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+interface FAQPageProps {
+  isDark: boolean;
+  onBack: () => void;
+}
+
+const faqs = [
+  {
+    q: 'Wie erstelle ich einen Job?',
+    a: 'Navigiere zum Job-Bereich und klicke auf "Neuen Job erstellen".',
+  },
+  {
+    q: 'Wie verdiene ich Karma Punkte?',
+    a: 'Karma erhältst du durch abgeschlossene Aufträge und Aktivität in der Community.',
+  },
+  {
+    q: 'Ist die Nutzung kostenlos?',
+    a: 'Die Grundfunktionen sind kostenlos. Premium bietet zusätzliche Vorteile.',
+  },
+];
+
+const FAQPage: React.FC<FAQPageProps> = ({ isDark, onBack }) => {
+  return (
+    <div className="flex-1 overflow-y-auto pb-32">
+      <div className="px-6 py-6 max-w-3xl mx-auto">
+        <div className="flex items-center space-x-4 mb-6">
+          <button
+            onClick={onBack}
+            className={`p-2 rounded-xl ${isDark ? 'hover:bg-slate-700' : 'hover:bg-gray-100'} transition-colors`}
+          >
+            <X className={`w-6 h-6 ${isDark ? 'text-white' : 'text-gray-900'}`} />
+          </button>
+          <div>
+            <h1 className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>FAQ</h1>
+            <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>Häufig gestellte Fragen</p>
+          </div>
+        </div>
+
+        <div className={`${isDark ? 'bg-slate-800/80 border-slate-700' : 'bg-white border-gray-200'} rounded-2xl border divide-y ${isDark ? 'divide-slate-700' : 'divide-gray-200'}`}>
+          {faqs.map((faq, idx) => (
+            <details key={idx} className="p-4">
+              <summary className={`cursor-pointer font-medium ${isDark ? 'text-white' : 'text-gray-900'} focus:outline-none`}>
+                {faq.q}
+              </summary>
+              <p className={`mt-2 text-sm ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>{faq.a}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FAQPage;

--- a/src/components/HelpPage.tsx
+++ b/src/components/HelpPage.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { X, Mail, Info } from 'lucide-react';
+
+interface HelpPageProps {
+  isDark: boolean;
+  onBack: () => void;
+}
+
+const HelpPage: React.FC<HelpPageProps> = ({ isDark, onBack }) => {
+  return (
+    <div className="flex-1 overflow-y-auto pb-32">
+      <div className="px-6 py-6 max-w-3xl mx-auto">
+        <div className="flex items-center space-x-4 mb-6">
+          <button
+            onClick={onBack}
+            className={`p-2 rounded-xl ${isDark ? 'hover:bg-slate-700' : 'hover:bg-gray-100'} transition-colors`}
+          >
+            <X className={`w-6 h-6 ${isDark ? 'text-white' : 'text-gray-900'}`} />
+          </button>
+          <div>
+            <h1 className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>Hilfe & Support</h1>
+            <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>Wir unterstützen dich gerne</p>
+          </div>
+        </div>
+
+        <div className={`${isDark ? 'bg-slate-800/80 border-slate-700' : 'bg-white border-gray-200'} rounded-2xl p-6 border space-y-4`}>
+          <p className={isDark ? 'text-gray-300' : 'text-gray-700'}>
+            In unserem <span className="font-semibold">FAQ</span> findest du Antworten auf häufige Fragen.
+            Solltest du keine Lösung finden, kontaktiere uns gerne direkt.
+          </p>
+
+          <div className="flex items-center space-x-3">
+            <Mail className="w-5 h-5 text-blue-500" />
+            <a
+              href="mailto:support@mutuus.de"
+              className="text-blue-500 hover:underline"
+            >
+              support@mutuus.de
+            </a>
+          </div>
+
+          <div className="flex items-center space-x-3">
+            <Info className="w-5 h-5 text-blue-500" />
+            <p className={isDark ? 'text-gray-300' : 'text-gray-700'}>
+              Besuche auch unser Forum für Austausch mit der Community.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HelpPage;

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -1,14 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import {
   User,
-  Settings,
+  BookOpen,
   CreditCard,
   HelpCircle,
   LogOut, 
   Moon, 
   Sun, 
   Bell,
-  Shield,
   FileText,
   Star,
   Crown,
@@ -24,6 +23,10 @@ import {
 import { supabase } from '../lib/supabase';
 import { products, getProductByPriceId } from '../stripe-config';
 import ProfileForm, { ProfileData } from './ProfileForm';
+import NotificationSettingsPage from './NotificationSettingsPage';
+import HelpPage from './HelpPage';
+import FAQPage from './FAQPage';
+import TermsPage from './TermsPage';
 
 interface MoreMenuProps {
   isDark: boolean;
@@ -46,6 +49,10 @@ const MoreMenu: React.FC<MoreMenuProps> = ({ isDark, onToggleTheme }) => {
   const [showPayments, setShowPayments] = useState(false);
   const [showPremium, setShowPremium] = useState(false);
   const [showKarmaStore, setShowKarmaStore] = useState(false);
+  const [showNotificationSettings, setShowNotificationSettings] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+  const [showFAQ, setShowFAQ] = useState(false);
+  const [showTerms, setShowTerms] = useState(false);
   const [checkoutLoading, setCheckoutLoading] = useState<string | null>(null);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -546,6 +553,46 @@ const MoreMenu: React.FC<MoreMenuProps> = ({ isDark, onToggleTheme }) => {
     );
   }
 
+  // Notification Settings Page
+  if (showNotificationSettings) {
+    return (
+      <NotificationSettingsPage
+        isDark={isDark}
+        onBack={() => setShowNotificationSettings(false)}
+      />
+    );
+  }
+
+  // Help Page
+  if (showHelp) {
+    return (
+      <HelpPage
+        isDark={isDark}
+        onBack={() => setShowHelp(false)}
+      />
+    );
+  }
+
+  // FAQ Page
+  if (showFAQ) {
+    return (
+      <FAQPage
+        isDark={isDark}
+        onBack={() => setShowFAQ(false)}
+      />
+    );
+  }
+
+  // Terms Page
+  if (showTerms) {
+    return (
+      <TermsPage
+        isDark={isDark}
+        onBack={() => setShowTerms(false)}
+      />
+    );
+  }
+
   // Main Menu
   const menuItems = [
     {
@@ -574,28 +621,28 @@ const MoreMenu: React.FC<MoreMenuProps> = ({ isDark, onToggleTheme }) => {
       icon: Bell,
       label: 'Benachrichtigungen',
       description: 'Push-Einstellungen',
-      onClick: () => {},
+      onClick: () => setShowNotificationSettings(true),
       color: 'text-purple-500'
-    },
-    {
-      icon: Shield,
-      label: 'Datenschutz',
-      description: 'Privatsphäre-Einstellungen',
-      onClick: () => {},
-      color: 'text-indigo-500'
     },
     {
       icon: HelpCircle,
       label: 'Hilfe & Support',
-      description: 'FAQ und Kontakt',
-      onClick: () => {},
+      description: 'Kontakt & Unterstützung',
+      onClick: () => setShowHelp(true),
       color: 'text-orange-500'
+    },
+    {
+      icon: BookOpen,
+      label: 'FAQ',
+      description: 'Häufige Fragen',
+      onClick: () => setShowFAQ(true),
+      color: 'text-indigo-500'
     },
     {
       icon: FileText,
       label: 'AGB & Datenschutz',
       description: 'Rechtliche Informationen',
-      onClick: () => {},
+      onClick: () => setShowTerms(true),
       color: 'text-gray-500'
     }
   ];

--- a/src/components/NotificationSettingsPage.tsx
+++ b/src/components/NotificationSettingsPage.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface NotificationSettingsPageProps {
+  isDark: boolean;
+  onBack: () => void;
+}
+
+const NotificationSettingsPage: React.FC<NotificationSettingsPageProps> = ({ isDark, onBack }) => {
+  const [settings, setSettings] = useState({
+    email: true,
+    push: true,
+    marketing: false,
+  });
+
+  const toggle = (key: keyof typeof settings) => {
+    setSettings(prev => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const options = [
+    { key: 'email', label: 'E-Mail Benachrichtigungen' },
+    { key: 'push', label: 'Push Benachrichtigungen' },
+    { key: 'marketing', label: 'Marketing Nachrichten' },
+  ] as const;
+
+  return (
+    <div className="flex-1 overflow-y-auto pb-32">
+      <div className="px-6 py-6 max-w-3xl mx-auto">
+        <div className="flex items-center space-x-4 mb-6">
+          <button
+            onClick={onBack}
+            className={`p-2 rounded-xl ${isDark ? 'hover:bg-slate-700' : 'hover:bg-gray-100'} transition-colors`}
+          >
+            <X className={`w-6 h-6 ${isDark ? 'text-white' : 'text-gray-900'}`} />
+          </button>
+          <div>
+            <h1 className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>Benachrichtigungen</h1>
+            <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>Push-Einstellungen</p>
+          </div>
+        </div>
+
+        <div className={`${isDark ? 'bg-slate-800/80 border-slate-700' : 'bg-white border-gray-200'} rounded-2xl p-6 border space-y-4`}>
+          {options.map(option => (
+            <div key={option.key} className="flex items-center justify-between">
+              <span className={isDark ? 'text-white' : 'text-gray-900'}>{option.label}</span>
+              <button
+                onClick={() => toggle(option.key)}
+                className={`w-10 h-6 flex items-center rounded-full p-1 transition-colors duration-300 ${settings[option.key] ? 'bg-blue-500' : isDark ? 'bg-slate-600' : 'bg-gray-300'}`}
+              >
+                <span
+                  className={`bg-white w-4 h-4 rounded-full shadow-md transform transition-transform duration-300 ${settings[option.key] ? 'translate-x-4' : ''}`}
+                />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationSettingsPage;

--- a/src/components/TermsPage.tsx
+++ b/src/components/TermsPage.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+interface TermsPageProps {
+  isDark: boolean;
+  onBack: () => void;
+}
+
+const TermsPage: React.FC<TermsPageProps> = ({ isDark, onBack }) => {
+  return (
+    <div className="flex-1 overflow-y-auto pb-32">
+      <div className="px-6 py-6 max-w-3xl mx-auto">
+        <div className="flex items-center space-x-4 mb-6">
+          <button
+            onClick={onBack}
+            className={`p-2 rounded-xl ${isDark ? 'hover:bg-slate-700' : 'hover:bg-gray-100'} transition-colors`}
+          >
+            <X className={`w-6 h-6 ${isDark ? 'text-white' : 'text-gray-900'}`} />
+          </button>
+          <div>
+            <h1 className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>AGB & Datenschutz</h1>
+            <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>Rechtliche Informationen</p>
+          </div>
+        </div>
+
+        <div className={`${isDark ? 'bg-slate-800/80 border-slate-700' : 'bg-white border-gray-200'} rounded-2xl p-6 border space-y-6`}>
+          <div>
+            <h2 className={`text-lg font-semibold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>Allgemeine Geschäftsbedingungen</h2>
+            <p className={`${isDark ? 'text-gray-300' : 'text-gray-700'} text-sm leading-relaxed`}>
+              Diese Seite dient als Platzhalter für die vollständigen AGB. Hier werden zukünftig die Bedingungen zur Nutzung der Plattform stehen.
+            </p>
+          </div>
+          <div>
+            <h2 className={`text-lg font-semibold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>Datenschutzerklärung</h2>
+            <p className={`${isDark ? 'text-gray-300' : 'text-gray-700'} text-sm leading-relaxed`}>
+              Informationen zur Verarbeitung personenbezogener Daten werden hier bereitgestellt.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TermsPage;


### PR DESCRIPTION
## Summary
- add dedicated notification settings with toggleable options
- provide help, FAQ, and terms pages with responsive layout
- wire new pages into the more menu navigation

## Testing
- `npm run lint` *(fails: 'isDark' defined but never used and unexpected any warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abcb8f3884832ea08706f819335d09