### PR TITLE
fix: guard role column migration when profiles table missing

### DIFF
--- a/supabase/migrations/20250827074523_nameless_block.sql
+++ b/supabase/migrations/20250827074523_nameless_block.sql
@@ -21,11 +21,16 @@
 -- Add role column to profiles table
 DO $$
 BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns 
-    WHERE table_name = 'profiles' AND column_name = 'role'
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name = 'profiles'
   ) THEN
-    ALTER TABLE profiles ADD COLUMN role text DEFAULT 'user';
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'profiles' AND column_name = 'role'
+    ) THEN
+      ALTER TABLE profiles ADD COLUMN role text DEFAULT 'user';
+    END IF;
   END IF;
 END $$;
 


### PR DESCRIPTION
## Summary
- prevent `ALTER TABLE profiles` errors by checking that the table exists before adding the `role` column

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 59 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aea19ac80c832eb3e34cce29246c4c