### PR TITLE
Replace deprecated npm http-proxy config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+proxy=http://proxy:8080
+https-proxy=http://proxy:8080


### PR DESCRIPTION
## Summary
- replace deprecated npm http-proxy configuration with supported proxy/https-proxy entries in .npmrc

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 63 problems (59 errors, 4 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68aea160a634832eb893a8ee84862734