### PR TITLE
Remove duplicate job action functions

### DIFF
--- a/src/components/admin/AdminJobs.tsx
+++ b/src/components/admin/AdminJobs.tsx
@@ -96,35 +96,6 @@ const AdminJobs: React.FC<AdminJobsProps> = ({ isDark }) => {
       console.error('Error deleting job:', error);
     }
   };
-  const updateJobStatus = async (jobId: string, newStatus: string) => {
-    try {
-      const { error } = await supabase
-        .from('jobs')
-        .update({ status: newStatus, updated_at: new Date().toISOString() })
-        .eq('id', jobId);
-
-      if (error) throw error;
-      loadJobs(); // Refresh data
-    } catch (error) {
-      console.error('Error updating job status:', error);
-    }
-  };
-
-  const deleteJob = async (jobId: string) => {
-    if (!confirm('Sind Sie sicher, dass Sie diesen Job löschen möchten?')) return;
-
-    try {
-      const { error } = await supabase
-        .from('jobs')
-        .delete()
-        .eq('id', jobId);
-
-      if (error) throw error;
-      loadJobs(); // Refresh data
-    } catch (error) {
-      console.error('Error deleting job:', error);
-    }
-  };
 
   const filteredJobs = jobs.filter(job => {
     const matchesSearch = job.title.toLowerCase().includes(searchTerm.toLowerCase()) ||


### PR DESCRIPTION
## Summary
- remove duplicate `updateJobStatus` and `deleteJob` declarations in AdminJobs component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aea3906c6c832eaae512a47aa60fed