### PR TITLE
Add schema reload for jobs difficulty column

### DIFF
--- a/supabase/migrations/20250901000000_refresh_jobs_difficulty.sql
+++ b/supabase/migrations/20250901000000_refresh_jobs_difficulty.sql
@@ -1,0 +1,25 @@
+/*
+  # Ensure difficulty column exists in jobs and refresh schema cache
+
+  1. Changes
+    - Add `difficulty` column to `jobs` table if missing
+    - Refresh PostgREST schema cache
+
+  2. Security
+    - No changes
+*/
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'jobs' AND column_name = 'difficulty'
+  ) THEN
+    ALTER TABLE jobs
+      ADD COLUMN difficulty text NOT NULL DEFAULT 'medium'
+      CHECK (difficulty IN ('easy', 'medium', 'hard'));
+  END IF;
+END $$;
+
+-- Refresh PostgREST schema cache so the new column is recognized
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Ensure `jobs` table includes a `difficulty` column and refresh PostgREST schema cache

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af4b1ccd50832e8368ee3163f0e743