### PR TITLE
Remove job category field and cleanup

### DIFF
--- a/src/components/CreateJobPage.tsx
+++ b/src/components/CreateJobPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { X, Euro, Star, Save, ChevronLeft, ChevronRight, Upload, Calendar, Clock, Image, Trash2, FileText } from 'lucide-react';
+import { X, Euro, Star, Save, ChevronLeft, ChevronRight, Upload, Calendar, Clock, Image, Trash2 } from 'lucide-react';
 import { User } from '@supabase/supabase-js';
-import { supabase, JobCategory } from '../lib/supabase';
+import { supabase } from '../lib/supabase';
 
 interface CreateJobPageProps {
   isDark: boolean;
@@ -13,32 +13,14 @@ interface CreateJobPageProps {
 const CreateJobPage: React.FC<CreateJobPageProps> = ({ isDark, user, jobType, onBack }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [selectedJobType, setSelectedJobType] = useState<'cash' | 'karma'>(jobType || 'cash');
-  const [categories, setCategories] = useState<JobCategory[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
-
   useEffect(() => {
     if (jobType) {
       setSelectedJobType(jobType);
     }
-    loadCategories();
   }, [jobType]);
-
-  const loadCategories = async () => {
-    try {
-      const { data, error } = await supabase
-        .from('job_categories')
-        .select('*')
-        .eq('is_active', true)
-        .order('name');
-
-      if (error) throw error;
-      setCategories(data || []);
-    } catch (error) {
-      console.error('Error loading categories:', error);
-    }
-  };
 
   const [jobData, setJobData] = useState({
     // Schritt 1: Grundlagen
@@ -48,7 +30,6 @@ const CreateJobPage: React.FC<CreateJobPageProps> = ({ isDark, user, jobType, on
     titleImageIndex: 0, // Index des Titelbildes
     
     // Schritt 2: Details
-    categoryId: '',
     location: 'remote',
     difficulty: 'easy',
     tags: '',
@@ -79,7 +60,7 @@ const CreateJobPage: React.FC<CreateJobPageProps> = ({ isDark, user, jobType, on
 
   const steps = [
     { number: 1, title: 'Grundlagen', description: 'Titel, Beschreibung & Medien' },
-    { number: 2, title: 'Details', description: 'Kategorie, Anforderungen & Lieferobjekte' },
+    { number: 2, title: 'Details', description: 'Anforderungen & Lieferobjekte' },
     { number: 3, title: 'Abschluss', description: 'Deadline & Bezahlung' }
   ];
 
@@ -135,7 +116,7 @@ const CreateJobPage: React.FC<CreateJobPageProps> = ({ isDark, user, jobType, on
       case 1:
         return jobData.title.trim() && jobData.description.trim();
       case 2:
-        return jobData.category && jobData.deliverables.trim();
+        return jobData.deliverables.trim();
       case 3:
         return jobData.deadlineDate && jobData.deadlineTime && 
                (selectedJobType === 'karma' ? jobData.karmaReward : 
@@ -160,7 +141,6 @@ const CreateJobPage: React.FC<CreateJobPageProps> = ({ isDark, user, jobType, on
         title: jobData.title,
         description: jobData.description,
         job_type: selectedJobType,
-        category_id: jobData.categoryId,
         location: jobData.location,
         difficulty: jobData.difficulty,
         tags: tagsArray,
@@ -396,40 +376,19 @@ const CreateJobPage: React.FC<CreateJobPageProps> = ({ isDark, user, jobType, on
       case 2:
         return (
           <div className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                  Kategorie *
-                </label>
-                <select
-                  value={jobData.categoryId}
-                  onChange={(e) => setJobData(prev => ({ ...prev, categoryId: e.target.value }))}
-                  className={`w-full px-4 py-3 rounded-xl border ${
-                    isDark ? 'bg-slate-700 border-slate-600 text-white' : 'bg-gray-50 border-gray-200 text-gray-900'
-                  }`}
-                  required
-                >
-                  <option value="">Kategorie wählen</option>
-                  {categories.map(cat => (
-                    <option key={cat.id} value={cat.id}>{cat.description || cat.name}</option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                  Standort
-                </label>
-                <input
-                  type="text"
-                  value={jobData.location}
-                  onChange={(e) => setJobData(prev => ({ ...prev, location: e.target.value }))}
-                  placeholder="Remote, Berlin, Hybrid..."
-                  className={`w-full px-4 py-3 rounded-xl border ${
-                    isDark ? 'bg-slate-700 border-slate-600 text-white placeholder-gray-400' : 'bg-gray-50 border-gray-200 text-gray-900 placeholder-gray-500'
-                  }`}
-                />
-              </div>
+            <div>
+              <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                Standort
+              </label>
+              <input
+                type="text"
+                value={jobData.location}
+                onChange={(e) => setJobData(prev => ({ ...prev, location: e.target.value }))}
+                placeholder="Remote, Berlin, Hybrid..."
+                className={`w-full px-4 py-3 rounded-xl border ${
+                  isDark ? 'bg-slate-700 border-slate-600 text-white placeholder-gray-400' : 'bg-gray-50 border-gray-200 text-gray-900 placeholder-gray-500'
+                }`}
+              />
             </div>
 
             <div>
@@ -709,12 +668,6 @@ const CreateJobPage: React.FC<CreateJobPageProps> = ({ isDark, user, jobType, on
                 <div className="flex justify-between">
                   <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>Titel:</span>
                   <span className={isDark ? 'text-white' : 'text-gray-900'}>{jobData.title}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>Kategorie:</span>
-                  <span className={isDark ? 'text-white' : 'text-gray-900'}>
-                    {categories.find(c => c.id === jobData.categoryId)?.description || 'Nicht ausgewählt'}
-                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>Medien:</span>

--- a/src/components/JobsPage.tsx
+++ b/src/components/JobsPage.tsx
@@ -33,22 +33,16 @@ const JobsPage: React.FC<JobsPageProps> = ({ isDark, user, userProfile }) => {
 
   const loadJobs = useCallback(async () => {
     try {
-      const { data, error } = await supabase
-        .from('job_posts')
-        .select(`
-          *,
-          job_categories (
-            name,
-            description,
-            icon,
-            color
-          ),
-          profiles (
-            full_name,
-            premium
-          ),
-          job_media (
-            id,
+        const { data, error } = await supabase
+          .from('job_posts')
+          .select(`
+            *,
+            profiles (
+              full_name,
+              premium
+            ),
+            job_media (
+              id,
             file_name,
             file_path,
             file_type,
@@ -82,7 +76,7 @@ const JobsPage: React.FC<JobsPageProps> = ({ isDark, user, userProfile }) => {
     return matchesSearch && matchesFilter;
   });
 
-  const formatPayment = (job: Job) => {
+    const formatPayment = (job: JobPost) => {
     if (job.job_type === 'cash') {
       const amount = job.fixed_amount || ((job.hourly_rate || 0) * job.estimated_hours);
       return `€${amount.toFixed(2)}`;
@@ -90,7 +84,7 @@ const JobsPage: React.FC<JobsPageProps> = ({ isDark, user, userProfile }) => {
     return `${job.karma_reward} Karma`;
   };
 
-  const getNetPayment = (job: Job) => {
+    const getNetPayment = (job: JobPost) => {
     if (job.job_type === 'cash') {
       const amount = job.fixed_amount || ((job.hourly_rate || 0) * job.estimated_hours);
       const commission = calculateJobCommission(amount, userProfile?.premium || false);

--- a/src/components/admin/AdminStats.tsx
+++ b/src/components/admin/AdminStats.tsx
@@ -126,7 +126,7 @@ const AdminStats: React.FC<AdminStatsProps> = ({ isDark, stats, loading }) => {
       </div>
 
       {/* Charts Row */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 gap-6">
         {/* Revenue Chart */}
         <div className={`${isDark ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'} rounded-2xl p-6 border`}>
           <div className="flex items-center justify-between mb-6">
@@ -144,34 +144,6 @@ const AdminStats: React.FC<AdminStatsProps> = ({ isDark, stats, loading }) => {
               <BarChart3 className={`w-12 h-12 ${isDark ? 'text-gray-400' : 'text-gray-400'} mx-auto mb-2`} />
               <p className={`${isDark ? 'text-gray-400' : 'text-gray-600'}`}>Umsatzdiagramm</p>
             </div>
-          </div>
-        </div>
-
-        {/* Job Categories */}
-        <div className={`${isDark ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'} rounded-2xl p-6 border`}>
-          <h3 className={`text-lg font-bold ${isDark ? 'text-white' : 'text-gray-900'} mb-6`}>
-            Job Kategorien
-          </h3>
-          <div className="space-y-4">
-            {[
-              { name: 'Entwicklung', count: 45, color: 'bg-blue-500' },
-              { name: 'Design', count: 32, color: 'bg-purple-500' },
-              { name: 'Marketing', count: 28, color: 'bg-green-500' },
-              { name: 'Texte', count: 19, color: 'bg-yellow-500' },
-              { name: 'Sonstiges', count: 15, color: 'bg-red-500' }
-            ].map((category, index) => (
-              <div key={index} className="flex items-center justify-between">
-                <div className="flex items-center space-x-3">
-                  <div className={`w-3 h-3 rounded-full ${category.color}`}></div>
-                  <span className={`${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                    {category.name}
-                  </span>
-                </div>
-                <span className={`font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                  {category.count}
-                </span>
-              </div>
-            ))}
           </div>
         </div>
       </div>

--- a/src/components/admin/AdminUsers.tsx
+++ b/src/components/admin/AdminUsers.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
 import {
   Users, Search, Crown, Shield,
   CheckCircle, XCircle, Star
 } from 'lucide-react';
-import { supabase } from '../../lib/supabase';
-
 interface AdminUsersProps {
   isDark: boolean;
 }
@@ -23,8 +21,8 @@ interface UserProfile {
 }
 
 const AdminUsers: React.FC<AdminUsersProps> = ({ isDark }) => {
-  const [users, setUsers] = useState<UserProfile[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [users] = useState<UserProfile[]>([]);
+  const [loading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [roleFilter, setRoleFilter] = useState('all');
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -9,24 +9,11 @@ if (!supabaseUrl || !supabaseAnonKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
-// Types for new job system
-export interface JobCategory {
-  id: string;
-  name: string;
-  description: string | null;
-  icon: string;
-  color: string;
-  is_active: boolean;
-  created_at: string;
-  updated_at: string;
-}
-
 export interface JobPost {
   id: string;
   title: string;
   description: string;
   job_type: 'cash' | 'karma';
-  category_id: string;
   location: string;
   difficulty: 'easy' | 'medium' | 'hard';
   tags: string[];
@@ -45,7 +32,6 @@ export interface JobPost {
   created_at: string;
   updated_at: string;
   // Relations
-  job_categories?: JobCategory;
   profiles?: Profile;
   job_media?: JobMedia[];
   job_applications?: JobApplication[];

--- a/supabase/migrations/20250915090000_remove_job_categories.sql
+++ b/supabase/migrations/20250915090000_remove_job_categories.sql
@@ -1,0 +1,9 @@
+-- Remove job categories and related references
+DROP INDEX IF EXISTS idx_job_posts_category_id;
+
+ALTER TABLE IF EXISTS job_posts DROP COLUMN IF EXISTS category_id;
+
+DROP POLICY IF EXISTS "Public can view active categories" ON job_categories;
+DROP POLICY IF EXISTS "Admins can manage categories" ON job_categories;
+
+DROP TABLE IF EXISTS job_categories;


### PR DESCRIPTION
## Summary
- remove category selection from job creation and related payload logic
- update job listings and admin stats to operate without categories
- drop job_categories table and references in schema

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af52947668832e8bbef1e98a668d9d